### PR TITLE
Use `post.title` as `disqus_title`

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -29,6 +29,7 @@ layout: default
   <script type="text/javascript">
     var disqus_shortname  = '{{ site.disqus_shortname }}';
     var disqus_identifier = '{{ page.id }}';
+    var disqus_title      = '{{ post.title }}';
 
     (function() {
       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;


### PR DESCRIPTION
By default, `disqus_title` is the `<title>` of the page, which contains "-- Pixyll" and isn't optimal.