### PR TITLE
Override font-weight in basscss

### DIFF
--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -15,6 +15,7 @@
 
 body {
   font-family: "Merriweather", "PT Serif", Georgia, "Times New Roman", serif;
+  font-weight: 300;
 }
 
 html, body {


### PR DESCRIPTION
After installing Merriweather locally and running in Safari I noticed that the font-weight of text in lists where bolder than otherwise.

This fixes the problem for me, but might make other `font-weight: 300` redundant, for example in paragraphs. Feel free to reject this pull request and solve the issue a better way.

You can reproduce the issue by downloading and installing the font from http://www.fontsquirrel.com/fonts/merriweather, make a list and run locally in Safari.
