### PR TITLE
Support setting a static minutes read on posts.

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,8 +12,14 @@ layout: default
   <span class="post-meta">{{ page.date | date: "%b %-d, %Y" }}</span><br>
   {% if page.update_date %}
     <span class="post-meta">Updated: {{ page.update_date | date: "%b %-d, %Y" }}</span><br>
+  {% endif %}  
+  <span class="post-meta small">
+  {% if page.minutes %}
+    {{ page.minutes }} minute read
+  {% else %}
+    {{ minutes }} minute read
   {% endif %}
-  <span class="post-meta small">{{ minutes }} minute read</span>
+  </span>
 </div>
 
 <article class="post-content">


### PR DESCRIPTION
Useful if you have a lot of invisible content, e.g. commented out with <!-- -->. These become part of the _minutes read_ calculation which then will be incorrect. My setting the `minutes` var in the YML frontmatter of the post you can bypass the calculation.
