### PR TITLE
Change description to summary

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,11 +20,10 @@
     {% endif %}
 
     <!-- Open Graph -->
-    <!-- From: https://github.com/mmistakes/hpstr-jekyll-theme/blob/master/_includes/head.html -->
     <meta property="og:locale" content="en_US">
     <meta property="og:type" content="article">
     <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
-    <meta property="og:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+    <meta property="og:description" content="{% if page.summary %}{{ page.summary }}{% else %}{{ site.description }}{% endif %}">
     <meta property="og:url" content="{{ site.url }}{{ page.url }}">
     <meta property="og:site_name" content="{{ site.title }}">
 


### PR DESCRIPTION
Don't know what the Jekyll convention is, but it seems that you always use summary, not description.

Right now it always shows the site description, never the blog summary.

I've also removed the link, is that really needed? It's just standard Open Graph tags (and also show up in the html)