### PR TITLE
Override reading length in YAML Frontmatter

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,9 +2,11 @@
 layout: default
 ---
 
-{% assign minutes = content | number_of_words | divided_by: 180 %}
-{% if minutes == 0 %}
-{% assign minutes = 1 %}
+{% if page.minutes %}
+  {% assign minutes = page.minutes %}
+{% else %}
+  {% assign minutes = content | number_of_words | divided_by: 180 %}
+  {% if minutes == 0 %}{% assign minutes = 1 %}{% endif %}
 {% endif %}
 
 <div class="post-header mb2">
@@ -13,13 +15,7 @@ layout: default
   {% if page.update_date %}
     <span class="post-meta">Updated: {{ page.update_date | date: "%b %-d, %Y" }}</span><br>
   {% endif %}  
-  <span class="post-meta small">
-  {% if page.minutes %}
-    {{ page.minutes }} minute read
-  {% else %}
-    {{ minutes }} minute read
-  {% endif %}
-  </span>
+  <span class="post-meta small">{{ minutes }} minute read</span>
 </div>
 
 <article class="post-content">


### PR DESCRIPTION
I made a modification to the code added by @rassol in 16fc4ea2c83eadd40781f914f8654567926e6b7e. 

I feel that overriding the already calculated value for the post read length is a little wasteful and bad for readability.

I've moved the code to the top so the value isn't even calculated if it is specified in the frontmatter.