### PR TITLE
Generate the summary using post.excerpt

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,13 @@ layout: default
         <a href="{{ post.url | prepend: site.baseurl }}" class="post-link">
           <p class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</p>
           <h3 class="h2 post-title">{{ post.title }}</h3>
-          <p class="post-summary">{{ post.summary }}</p>
+          <p class="post-summary">
+            {% if post.summary %}
+              {{ post.summary }}
+            {% else %}
+              {{ post.excerpt }}
+            {% endif %}
+          </p>
         </a>
       </div>
     {% endfor %}


### PR DESCRIPTION
The post summary is either taken from `post.summary` or generated using `post.excerpt`.

This resolves #140