### PR TITLE
REMOVE disqus_identifier so default is used.

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -32,7 +32,6 @@ layout: default
   <div id="disqus_thread"></div>
   <script type="text/javascript">
     var disqus_shortname  = '{{ site.disqus_shortname }}';
-    var disqus_identifier = '{{ page.id }}';
 
     (function() {
       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;


### PR DESCRIPTION
This is mentioned in #150