### PR TITLE
Added Share on Hacker News functionality with Bootstrap button

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,6 +41,7 @@ share_digg: false
 share_tumblr: false
 share_reddit: false
 share_stumbleupon: false
+share_hackernews: false
 
 # Build settings
 markdown:     redcarpet

--- a/_includes/share_buttons.html
+++ b/_includes/share_buttons.html
@@ -33,5 +33,11 @@
     {% if site.share_stumbleupon %}
       <a class="fa fa-stumbleupon" href="http://www.stumbleupon.com/submit?url={{ site.url }}{{ page.url }}&title={{ page.title }}" rel="nofollow" target="_blank" title="Share on StumbleUpon"></a>
     {% endif %}
+
+    {% if site.share_hackernews %}
+      <a class = "fa fa-hacker-news" onclick="parent.postMessage('submit','*')" href="https://news.ycombinator.com/submitlink?u={{ site.url }}{{ page.url }}&t={{ page.title }}" rel="nofollow" target="_blank" title="Share on Hacker News"></a>
+    {% endif %}
+
+
   </div>
 </div>


### PR DESCRIPTION
Appreciate the great theme. I added a Hacker News button for sharing if you are interested. 

You can see an example here:  `https://nrakochy.github.io/miscellanea/share-button/2015/04/14/Hello-Hacker-News/`

It requires the user to be logged in to HN, and it fills in the submission form without actually submitting it. 