### PR TITLE
update README to reflect change to Formspree

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,12 @@ A relevant Jekyll Github Issue: <https://github.com/jekyll/jekyll/issues/332>
 
 ### Contact Form
 
-If you'd like to keep the contact form, which uses <http://forms.brace.io/>, you will need to update the email address.
+If you'd like to keep the contact form, which uses <http://formspree.io/>, you will need to update the email address.
 
 Currently, the `contact.md` has the following:
 
 ```html
-<form action="https://forms.brace.io/johnotander@icloud.com" method="POST" class="form-stacked form-light">
+<form action="https://formspree.io/johnotander@icloud.com" method="POST" class="form-stacked form-light">
 ```
 
 Where it says `johnotander@icloud.com`, you will need to change that to the email that you wish to have the form data sent to. It will require you to fill the form out when you push it live for the first time so that you can confirm your email.


### PR DESCRIPTION
This updates the Contact Form documentation in the `README` to reflect that Brace Forms has moved over to Formspree. See #104