### PR TITLE
Fix bug: the social icons are always in the center

### DIFF
--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -47,8 +47,3 @@
 .site-header .site-nav {
   text-align: center;
 }
-
-.social-icons .left, .social-icons .right {
-  text-align: center;
-  float: none;
-}


### PR DESCRIPTION
When I displayed icons for social networks, they appear in the center of the page. I've found out, that the problem in _header.scss. I've removed unnecessary code, that caused the bug. 