### PR TITLE
Don't use rems for media queries

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -27,9 +27,9 @@ $abbr-border-bottom: 1px black dotted;
 $measure-width: 42rem !default;
 
 // Viewport widths
-$viewport-small: 32rem;
-$viewport-medium: 48rem;
-$viewport-large: 64rem;
+$viewport-small: 32em;
+$viewport-medium: 48em;
+$viewport-large: 64em;
 
 // Colors
 $blue: #0076df !default;


### PR DESCRIPTION
Turns out it is a known bug that rem units in media queries causes
webkit to go crazy, so this fixes that.

Closes #183
Closes #179