### PR TITLE
Add support for a bitbucket social link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,7 @@ disqus_shortname:
 
 # Social icons
 github_username:
+bitbucket_username:
 stackoverflow_id:
 twitter_username:
 google_plus_id:

--- a/_includes/social_links.html
+++ b/_includes/social_links.html
@@ -3,6 +3,9 @@
     {% if site.github_username %}
       <a class="fa fa-github" href="https://github.com/{{ site.github_username }}"></a>
     {% endif %}
+    {% if site.bitbucket_username %}
+      <a class="fa fa-bitbucket" href="https://bitbucket.org/{{ site.bitbucket_username }}"></a>
+    {% endif %}
     {% if site.stackoverflow_id %}
       <a class="fa fa-stack-overflow" href="https://stackoverflow.com/users/{{ site.stackoverflow_id }}"></a>
     {% endif %}


### PR DESCRIPTION
I think this nice theme needs a social link/icon for bitbucket.org, which I am planning to use a lot. In this simple pull request I added support just for that.