### PR TITLE
Allow for wider images

### DIFF
--- a/_posts/2014-06-10-see-pixyll-in-action.md
+++ b/_posts/2014-06-10-see-pixyll-in-action.md
@@ -72,6 +72,8 @@ This allows your content to have the proper informational and contextual hierarc
 
 ![desk](https://cloud.githubusercontent.com/assets/1424573/3378137/abac6d7c-fbe6-11e3-8e09-55745b6a8176.png)
 
+_![desk](https://cloud.githubusercontent.com/assets/1424573/3378137/abac6d7c-fbe6-11e3-8e09-55745b6a8176.png)_
+
 
 ### There are also pretty colors
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -19,8 +19,8 @@ html, body {
 }
 
 em img {
-  max-width: 78em;
-  margin-left: -14em;
+  max-width: 56em;
+  margin-left: -7em;
 }
 
 body {

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -19,7 +19,7 @@ html, body {
 }
 
 em img {
-  max-width: 56em;
+  max-width: $measure-width + 14;
   margin-left: -7em;
 }
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -18,10 +18,6 @@ html, body {
   min-height: 100%;
 }
 
-img {
-  max-width: 100%;
-}
-
 em img {
   max-width: 78em;
   margin-left: -14em;

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -19,8 +19,12 @@ html, body {
 }
 
 img {
-  width: auto;
   max-width: 100%;
+}
+
+em img {
+  max-width: 78em;
+  margin-left: -14em;
 }
 
 body {

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -18,6 +18,10 @@ html, body {
   min-height: 100%;
 }
 
+img {
+  max-width: 100%;
+}
+
 em img {
   max-width: $measure-width + 14;
   margin-left: -7em;

--- a/_sass/_media-queries.scss
+++ b/_sass/_media-queries.scss
@@ -42,7 +42,7 @@
   }
 }
 
-@media screen and (max-width: $viewport-large) {
+@media screen and (max-width: $viewport-large){
   html {
     font-size: 20px;
   }

--- a/_sass/_media-queries.scss
+++ b/_sass/_media-queries.scss
@@ -42,8 +42,12 @@
   }
 }
 
-@media screen and (min-width: $viewport-large) {
+@media screen and (max-width: $viewport-large) {
   html {
     font-size: 20px;
+  }
+  em img {
+    max-width: 100%;
+    margin-left: 0;
   }
 }

--- a/_sass/_media-queries.scss
+++ b/_sass/_media-queries.scss
@@ -42,10 +42,13 @@
   }
 }
 
-@media screen and (max-width: $viewport-large){
+@media screen and (min-width: $viewport-large){
   html {
     font-size: 20px;
   }
+}
+
+@media screen and (max-width: $viewport-large){
   em img {
     max-width: 100%;
     margin-left: 0;


### PR DESCRIPTION
Inspired by [this post](http://audaciousfox.com/2015/01/19/beautiful-images-with-css.html), I decided to try add the ability to include wider images at the large-viewport width.

It mostly works, except for between max width and medium-viewport, where the image isn't scaling properly with the page width. I'm not sure how to fix that. Any ideas?