### PR TITLE
Fixed flex shorthand to make the footer work properly on IE10+

### DIFF
--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -14,8 +14,8 @@
 .site-wrap {
   -webkit-box-flex: 1;
   -webkit-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+      -ms-flex: 1 0 auto;
+          flex: 1 0 auto;
 }
 
 footer {


### PR DESCRIPTION
This is mentioned in #211 

Basically, IE needs to have explicitly set `flex-grow`, `flex-basis` and `flex-shrink` in the shorthand.