### PR TITLE
medium-style link underlines

### DIFF
--- a/_posts/2014-06-10-see-pixyll-in-action.md
+++ b/_posts/2014-06-10-see-pixyll-in-action.md
@@ -9,8 +9,8 @@ categories: jekyll pixyll
 There is a significant amount of subtle, yet precisely calibrated, styling to ensure
 that your content is emphasized while still looking aesthetically pleasing.
 
-All links are easy to [locate and discern](#), yet don't detract from the harmony
-of a paragraph. The _same_ goes for italics and __bold__ elements. Even the the strikeout
+All links are easy to [locate and discern](#), yet don't detract from the [harmony
+of a paragraph](#). The _same_ goes for italics and __bold__ elements. Even the the strikeout
 works if <del>for some reason you need to update your post</del>. For consistency's sake,
 <ins>The same goes for insertions</ins>, of course.
 

--- a/_sass/_links.scss
+++ b/_sass/_links.scss
@@ -1,5 +1,12 @@
 a {
   color: $link-color;
+  background-image: linear-gradient(to top,
+    rgba(0,0,0,0) 13%,
+    rgba($link-color,.8) 13%,
+    rgba($link-color,.8) 17%,
+    rgba(0,0,0,0) 17%
+  );
+  text-shadow: white 1px 0px 0px, white -1px 0px 0px;
 }
 
 a:hover,
@@ -8,4 +15,11 @@ a:active {
   border: 0;
   color: $link-hover-color;
   text-decoration: none;
+  background-image: linear-gradient(to top,
+    rgba(0,0,0,0) 13%,
+    rgba($link-hover-color,.8) 13%,
+    rgba($link-hover-color,.8) 17%,
+    rgba(0,0,0,0) 17%
+  );
+  text-shadow: white 1px 0px 0px, white -1px 0px 0px;
 }


### PR DESCRIPTION
Looks good across browsers and sizes (at least on mac, although I assume windows is fine too if medium is using this). Color is still set by `$link-color` and `$link-hover-color`, set it to black for the full medium effect.

![image](https://cloud.githubusercontent.com/assets/1335122/11384470/ec103cb0-92c4-11e5-8e38-d07e7a5caf32.png)