### PR TITLE
Add jekyll-paginate to allow for pagination

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,3 +63,6 @@ permalink:    pretty
 paginate:     4
 sass:
   compressed: true
+gems:
+  -
+    jekyll-paginate


### PR DESCRIPTION
It sounds like jekyll-paginate is being phased out, but adding this gem will get the site working until another solution can be found.