### PR TITLE
Exclude vendor folder

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,8 +24,8 @@ disqus_shortname:
 
 # Facebook Comments plugin
 # (leave blank to disable Facebook Comments, otherwise set it to true)
-facebook_comments: 
-facebook_appid: 
+facebook_comments:
+facebook_appid:
 facebook_comments_number: 10
 
 # Social icons
@@ -66,3 +66,5 @@ sass:
 gems:
   - jekyll-paginate
   - jekyll-sitemap
+# https://github.com/jekyll/jekyll/issues/2938
+exclude: [vendor]


### PR DESCRIPTION
After install dependencies via `Bundler`, i'm trying run `jekyll serve`:

```bash
$ jekyll serve --watch
```

But i get the following error:

```bash
Configuration file: /Users/mgrachev/pixyll/_config.yml
            Source: /Users/mgrachev/pixyll
       Destination: /Users/mgrachev/pixyll/_site
      Generating...
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    Invalid date '0000-00-00': Post '/vendor/bundle/gems/jekyll-2.4.0/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the filename.
```

This is because, all the dependencies of the project are located in the directory `vendor/bundle`
To fix this problem need to add to the file `_config.yml` the following line:

```yaml
exclude: [vendor]
```
Source: https://github.com/jekyll/jekyll/issues/2938