### PR TITLE
Add jekyll-sitemap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,3 +65,4 @@ sass:
   compressed: true
 gems:
   - jekyll-paginate
+  - jekyll-sitemap


### PR DESCRIPTION
Gem `jekyll-sitemap` automatically generates a file `sitemap.xml` for your site with following contents:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <url>
    <loc>http://pixyll.com/jekyll/pixyll/2015/07/11/announcing-pixyll-version-2/</loc>
    <lastmod>2015-07-11T00:00:00+03:00</lastmod>
  </url>
  <url>
    <loc>http://pixyll.com/jekyll/pixyll/2014/06/11/welcome-to-pixyll/</loc>
    <lastmod>2014-06-11T19:31:19+04:00</lastmod>
  </url>
  <url>
    <loc>http://pixyll.com/jekyll/pixyll/2014/06/10/see-pixyll-in-action/</loc>
    <lastmod>2014-06-10T16:31:19+04:00</lastmod>
  </url>
  <url>
    <loc>http://pixyll.com/jekyll/pixyll/2014/06/09/so-what-is-jekyll/</loc>
    <lastmod>2014-06-09T16:32:18+04:00</lastmod>
  </url>
  <url>
    <loc>http://pixyll.com/jekyll/pixyll/2014/06/08/pixyll-has-pagination/</loc>
    <lastmod>2014-06-08T15:21:29+04:00</lastmod>
  </url>
  <url>
    <loc>http://pixyll.com/404.html</loc>
  </url>
  <url>
    <loc>http://pixyll.com/about/</loc>
  </url>
  <url>
    <loc>http://pixyll.com/contact/</loc>
  </url>
  <url>
    <loc>http://pixyll.com/</loc>
  </url>
  <url>
    <loc>http://pixyll.com/thanks/</loc>
  </url>
  <url>
    <loc>http://pixyll.com/page2/</loc>
  </url>
</urlset>
```

