### PR TITLE
Nav fix

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,2 +1,10 @@
-<a href="{{ site.baseurl }}/about/">About</a>
-<a href="{{ site.baseurl }}/contact/">Contact</a>
+{% for page in site.pages %}
+    {% if page.tags contains "about" %}
+        <a href="{{ page.url }}">{{ page.title }}</a>
+    {% endif %}
+{% endfor %}
+{% for page in site.pages %}
+    {% if page.tags contains "contact" %}
+        <a href="{{ page.url }}">{{ page.title }}</a>
+    {% endif %}
+{% endfor %}

--- a/about.md
+++ b/about.md
@@ -2,6 +2,7 @@
 layout: page
 title: About Pixyll
 permalink: /about/
+tags: about
 ---
 
 This Jekyll theme was crafted with <3 by [John Otander](http://johnotander.com)

--- a/contact.html
+++ b/contact.html
@@ -2,6 +2,7 @@
 layout: page
 title: Say Hello
 permalink: /contact/
+tags: about
 ---
 
 <div class="py2">

--- a/contact.html
+++ b/contact.html
@@ -2,7 +2,7 @@
 layout: page
 title: Say Hello
 permalink: /contact/
-tags: about
+tags: contact
 ---
 
 <div class="py2">


### PR DESCRIPTION
I am using different urls for about and contact pages and realized the default in navigation is hard coded in navigation -as well as the title for these hrefs-. So this is a fix using page tags and rendering the href for actual page url and title.