### PR TITLE
Add missing @ symbol

### DIFF
--- a/_includes/social_links.html
+++ b/_includes/social_links.html
@@ -26,7 +26,7 @@
       <a class="fa fa-angellist" href="https://angel.co/{{ site.angellist_username }}"></a>
     {% endif %}
     {% if site.medium_id %}
-      <a class="fa fa-medium" href="https://medium.com/{{ site.medium_id }}"></a>
+      <a class="fa fa-medium" href="https://medium.com/@{{ site.medium_id }}"></a>
     {% endif %}
   </div>
   <div class="right">


### PR DESCRIPTION
Medium user page names are prepended with an @ symbol in the URL.