### PR TITLE
Add optional support for mathjax

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -64,6 +64,12 @@
     <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
     <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
 
+    {% if site.mathjax %}
+    <script type="text/javascript" async
+            src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
+    </script>
+    {% endif %}
+
     {% if site.google_analytics %}
     <script type="text/javascript">
       var _gaq = _gaq || [];


### PR DESCRIPTION
After this commit, users can put:

```yaml
mathjax: true
```

into their _config.yml to have MathJax render equations in their markdown.