### PR TITLE
Add option to include extended latin fonts.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,7 @@ show_post_footers:    false
 show_social_icons:    false
 ajaxify_contact_form: false
 enable_mathjax: false
+extended_fonts: false
 
 # Disqus post comments
 # (leave blank to disable Disqus)

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,8 +13,13 @@
     <link rel="stylesheet" href="{{ "/css/pixyll.css" | prepend: site.baseurl }}?{{ site.time | date: "%Y%m%d%H%M" }}" type="text/css">
 
     <!-- Fonts -->
+    {% if site.extended_fonts %}
+    <link href='//fonts.googleapis.com/css?family=Merriweather:900,900italic,300,300italic&subset=latin-ext,latin' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Lato:900,300&subset=latin-ext,latin' rel='stylesheet' type='text/css'>
+    {% else %}
     <link href='//fonts.googleapis.com/css?family=Merriweather:900,900italic,300,300italic' rel='stylesheet' type='text/css'>
     <link href='//fonts.googleapis.com/css?family=Lato:900,300' rel='stylesheet' type='text/css'>
+    {% endif %}
     {% if site.show_social_icons or site.show_sharing_icons %}
       <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" rel="stylesheet">
     {% endif %}


### PR DESCRIPTION
Allows user to toggle extended latin fonts, needed to properly display some [diacritics](https://en.wikipedia.org/wiki/Diacritic), like for example

> ą ź ć ł

from Polish character set. The option is `extended_fonts: false`, set to false by default in order to maintain speed if additional characters are not needed.