### PR TITLE
Support for some SEO & related stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ You can measure visits to your website either by using simple [Google Analytics]
 * _Do not_ set both of above methods because this will cause conflicts and skew your reporting data.
 * Remember that you need to properly configure the GTM container in its admin panel if you want it to work. More info in [GTM's docs](https://www.google.com/analytics/tag-manager/resources/).
 
-Your website is by default set to be allowed for crawling and indexing for search engines. (Unless you made yourself some custom robots.txt file). You can use front matter settings on each page to control how search engines will treat react. Sometimes you may want to exclude just one particular page from indexing or forbid Google to store a copy of your page in its cache. It is up to you. Use `meta_robots` and assign values based on [this table](https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag?hl=en#valid-indexing--serving-directives). Some examples:
+Your website is by default set to be allowed for crawling and indexing by search engines. (Unless you made yourself some custom robots.txt file). You can use front matter settings on each page to control how search engines will treat react. Sometimes you may want to exclude just one particular page from indexing or forbid Google to store a copy of your page in its cache. It is up to you. Use `meta_robots` and assign values based on [this table](https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag?hl=en#valid-indexing--serving-directives). Some examples:
 
 ```yaml
 # exclude page from index

--- a/README.md
+++ b/README.md
@@ -145,6 +145,36 @@ If you would like to add a [fade-in-down effect](http://daneden.github.io/animat
 
 If you want to give credit to the Pixyll theme with a link to <http://pixyll.com> or my personal website <http://johnotander.com> somewhere, that'd be awesome. No worries if you don't.
 
+### Web analytics and search engines
+
+You can measure visits to your website either by using simple [Google Analytics](https://www.google.com/analytics/) tracking embed or more advanced [Google Tag Manager](https://www.google.com/analytics/tag-manager/) container.
+* For Google Analytics set up the value for `google_analytics`, it should be something like `google_analytics: UA-XXXXXXXX-X`.
+* For Google Tag Manager set up the value for `google_tag_manager`, it should be something like: `google_tag_manager: GTM-XXXXX`.
+* _Do not_ set both of above methods because this will cause conflicts and skew your reporting data.
+* Remember that you need to properly configure the GTM container in its admin panel if you want it to work. More info in [GTM's docs](https://www.google.com/analytics/tag-manager/resources/).
+
+Your website is by default set to be allowed for crawling and indexing for search engines. (Unless you made yourself some custom robots.txt file). You can use front matter settings on each page to control how search engines will treat react. Sometimes you may want to exclude just one particular page from indexing or forbid Google to store a copy of your page in its cache. It is up to you. Use `meta_robots` and assign values based on [this table](https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag?hl=en#valid-indexing--serving-directives). Some examples:
+
+```yaml
+# exclude page from index
+meta_robots: noindex
+
+# allow indexing, disallow caching
+meta_robots: noarchive
+
+# allow indexing, disallow crawling links
+meta_robots: nofollow
+
+# disallow indexing, follow links
+meta_robots: noindex,follow
+```
+
+In order to get more information about your website's status in search engines, you can register it in [Google Search Console](https://www.google.com/webmasters/tools/home) and/or [Bing Webmaster Tools](http://www.bing.com/toolbox/webmaster). Both these tools will ask you to authorize your website with them and there are couple of ways to do that. Pixyll supports verification via meta tags - just fill up values for `google_verification` and/or `bing_verification` in `_config.yml` with verification strings and meta tags will pop automatically.
+
+If search engine optimization is your thing, you can also set up `meta_description` values for each page/post. By default Pixyll uses `summary` to populate the `<meta name="description" content="...">` tag and falls back to `description` from `_config.yml` if `summary` is not present in page/post's front matter. The `summary` is also used for generating Open Graph tags. Why would you want to use a dedicated variable for meta description? Because character limit to properly display this description in search results (as a snippet) is way smaller than in Open Graph. It is recommended to keep it at 155-160 characters, for more in-depth info read [this article](https://moz.com/blog/i-cant-drive-155-meta-descriptions-in-2015).
+
+And lastly - if you happen to write in language other than English be sure to change `og_locale` in `_config.yml` to reflect it.
+
 ### Enjoy
 
 I hope you enjoy using Pixyll. If you encounter any issues, please feel free to let me know by creating an [issue](https://github.com/johnotander/pixyll/issues). I'd love to help.

--- a/_config.yml
+++ b/_config.yml
@@ -94,7 +94,7 @@ text:
       sent:     'Message sent!'
       error:    'Error!'
   thanks: 'Thanks for contacting us. We will reply as soon as possible.'
-
+  og_locale: 'en_US'
 
 # Build settings
 markdown:     kramdown

--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,8 @@ google_verification:
 # - using both will skew your data (leave blank to not use at all)
 google_analytics:
 google_tag_manager:
+# Bing services
+bing_verification:
 
 # Optional features
 animated:             false

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>{% if page.title %}{{ page.title | strip_html }} &#8211; {% endif %}{{ site.title | strip_html }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="{% if page.summary %}{{ page.summary | xml_escape }}{% else %}{{ site.description | xml_escape }}{% endif %}">
+    <meta name="description" content="{% if page.meta_description %}{{ page.meta_description | xml_escape }}{% elsif page.summary %}{{ page.summary | xml_escape }}{% else %}{{ site.description | xml_escape }}{% endif %}">
+    {% if page.meta_robots %}<meta name="robots" content="{{ page.meta_robots }}">
+    {% else %}<meta name="robots" content="all">{% endif %}
     <meta name="author" content="{{ site.author }}">
     {% if page.categories %}<meta name="keywords" content="{{ page.categories | join: ', ' }}">{% endif %}
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
@@ -34,10 +36,13 @@
     {% if site.google_verification %}
       <meta name="google-site-verification" content="{{ site.google_verification }}" />
     {% endif %}
+    {% if site.bing_verification %}
+      <meta name="msvalidate.01" content="{{ site.bing_verification }}" />
+    {% endif %}
 
     <!-- Open Graph -->
     <!-- From: https://github.com/mmistakes/hpstr-jekyll-theme/blob/master/_includes/head.html -->
-    <meta property="og:locale" content="en_US">
+    <meta property="og:locale" content="{{ site.text.og_locale }}">
     <meta property="og:type" content="article">
     <meta property="og:title" content="{% if page.title %}{{ page.title | xml_escape }}{% else %}{{ site.title | xml_escape }}{% endif %}">
     <meta property="og:description" content="{% if page.description %}{{ page.description | xml_escape }}{% else %}{{ site.description | xml_escape }}{% endif %}">


### PR DESCRIPTION
Added support for some SEO & related stuff:

* Specify verification string for Bing Webmaster Tools
* Control robots by settings in front matter of each page/post
* Option to have a separate string for meta description tag in front matter
* Option to change Open Graph locale setting
* Updated README.md with proper help entries