### PR TITLE
Add support for AnchorJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ If you would like to add a [fade-in-down effect](http://daneden.github.io/animat
 
 ### AnchorJS
 
-[AnchorJS](https://github.com/bryanbraun/anchorjs): _A JavaScript utility for adding deep anchor links to existing page content. AnchorJS is lightweight, accessible, and has no dependencies._ You can turn it on by toggling `enable_anchorjs`. Since it offers many ways for customization, such tweaks should be done in and default settings after turning AnchorJS on are:
+[AnchorJS](https://github.com/bryanbraun/anchorjs): _A JavaScript utility for adding deep anchor links to existing page content. AnchorJS is lightweight, accessible, and has no dependencies._ You can turn it on by toggling `enable_anchorjs`. Because it offers many ways for customization, tweaks should be done in `_includes/footer.html`. Default settings after turning AnchorJS on are:
 
 ```html
 <script>

--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ All variables can be found in the `_sass/_variables.scss` file, toggle these as 
 
 If you would like to add a [fade-in-down effect](http://daneden.github.io/animate.css/), you can add `animated: true` to your `_config.yml`.
 
+### AnchorJS
+
+[AnchorJS](https://github.com/bryanbraun/anchorjs): _A JavaScript utility for adding deep anchor links to existing page content. AnchorJS is lightweight, accessible, and has no dependencies._ You can turn it on by toggling `enable_anchorjs`. Since it offers many ways for customization, such tweaks should be done in and default settings after turning AnchorJS on are:
+
+```html
+<script>
+    anchors.options.visible = 'always';
+    anchors.add('article h2, article h3, article h4, article h5, article h6');
+</script>
+```
+
+See [documentation](http://bryanbraun.github.io/anchorjs/#basic-usage) for more options.
+
 ### Put in a Pixyll Plug
 
 If you want to give credit to the Pixyll theme with a link to <http://pixyll.com> or my personal website <http://johnotander.com> somewhere, that'd be awesome. No worries if you don't.

--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,7 @@ show_social_icons:    false
 ajaxify_contact_form: false
 enable_mathjax: false
 extended_fonts: false
+enable_anchorjs: false
 
 # Disqus post comments
 # (leave blank to disable Disqus)

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,3 +6,9 @@
     </small>
   </div>
 </footer>
+{% if site.enable_anchorjs %}<!-- AnchorJS -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/3.0.0/anchor.min.js"></script>
+<script>
+    anchors.options.visible = 'always';
+    anchors.add('article h2, article h3, article h4, article h5, article h6');
+</script>{% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,9 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>{% if page.title %}{{ page.title | strip_html }} &#8211; {% endif %}{{ site.title | strip_html }}</title>
+    <link rel="dns-prefetch" href="//maxcdn.bootstrapcdn.com">
+    <link rel="dns-prefetch" href="//cdn.mathjax.org">
+    <link rel="dns-prefetch" href="//cdnjs.cloudflare.com">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{% if page.meta_description %}{{ page.meta_description | xml_escape }}{% elsif page.summary %}{{ page.summary | xml_escape }}{% else %}{{ site.description | xml_escape }}{% endif %}">
     {% if page.meta_robots %}<meta name="robots" content="{{ page.meta_robots }}">

--- a/_sass/_links.scss
+++ b/_sass/_links.scss
@@ -38,3 +38,16 @@ button,
   text-shadow: none;
   background-image: none;
 }
+
+.anchorjs-link {
+    text-shadow: none;
+    background-image: none;
+}
+.anchorjs-link:hover,
+.anchorjs-link:focus,
+.anchorjs-link:active{
+    border: 0;
+    color: $link-hover-color;
+    text-shadow: none;
+    background-image: none;
+}


### PR DESCRIPTION
This will add option to include [AnchorJS](http://bryanbraun.github.io/anchorjs/) as a script loaded via CDN. Toggler is `enable_anchorjs` in `_config.yml`. The lib and launcher are declared in `_includes/footer.html`. I did not add additional options as entries in `_config.yml` because the lib has just to many tweaking possibilities, so it should be easier for anyone interested just to do it in `_includes/footer.html`.

There are also tweaks in `_sass/_links.scss` which were needed in order for anchor icons rendering without underlines - please @johnotander take a look on it because I am not sure if this is done properly.