### PR TITLE
Fix the pagination links when using custom pagination path

### DIFF
--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -4,7 +4,7 @@
       {% if paginator.page == 2 %}
         <a class="pagination-item" href="{{ site.baseurl }}/">{{ site.text.pagination.newer }}</a>
       {% else %}
-        <a class="pagination-item" href="{{ site.baseurl }}/page{{paginator.previous_page}}/">{{ site.text.pagination.newer }}</a>
+        <a class="pagination-item" href="{{ paginator.previous_page_path }}">{{ site.text.pagination.newer }}</a>
       {% endif %}
     {% else %}
       <span class="pagination-item disabled">{{ site.text.pagination.newer }}</span>
@@ -12,7 +12,7 @@
   </div>
   <div class="right">
     {% if paginator.next_page %}
-      <a class="pagination-item" href="{{ site.baseurl }}/page{{paginator.next_page}}/">{{ site.text.pagination.older }}</a>
+      <a class="pagination-item" href="{{ paginator.next_page_path }}">{{ site.text.pagination.older }}</a>
     {% else %}
       <span class="pagination-item disabled">{{ site.text.pagination.older }}</span>
     {% endif %}


### PR DESCRIPTION
Pagination links are broken when using a custom pagination_path option (ex. /page/:num/). Here's the tested fix for the issue.