### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ $ gem install bundler # If you don't have bundler installed
 $ bundle install
 ```
 
+If you don't want to install anything in your local machine, you can create a free development environment for this Pixyll project in the cloud on [Nitrous.io](https://www.nitrous.io) by clicking the button below.
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+In the IDE, start Pixyll via `Run > Start Pixyll` and access your site via `Preview > 3000`.
+
 #### Verify your Jekyll version
 
 It's important to also check your version of Jekyll since this project uses Native Sass which

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,13 @@
+# Setup
+
+Welcome to your Pixyll project on Nitrous.
+
+## Running the Jekyll server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), start Pixyll via "Run > Start Pixyll"
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 3000".

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,10 @@
+{
+  "template": "jekyll",
+  "ports": [3000],
+  "name": "Pixyll",
+  "description": "A simple, beautiful Jekyll theme that's mobile first.",
+  "scripts": {
+    "post-create": "bundle install",
+    "Start Pixyll": "cd ~/code/pixyll && jekyll serve --host 0.0.0.0 --port 3000"
+  }
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages