### PR TITLE
Add current page position between navigation buttons for pagination

### DIFF
--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -17,4 +17,5 @@
       <span class="pagination-item disabled">{{ site.text.pagination.older }}</span>
     {% endif %}
   </div>
+  <div class="pagination-meta">Page {{ paginator.page }} of {{ paginator.total_pages }}</div>
 </div>

--- a/_sass/_pagination.scss
+++ b/_sass/_pagination.scss
@@ -16,8 +16,12 @@
   padding: 1em 1.5em;
 }
 
-.pagination .disabled {
+.pagination .disabled, .pagination .pagination-meta {
   opacity: 0.5;
+}
+
+.pagination .pagination-meta {
+  overflow: hidden;
 }
 
 .pagination a:hover, .pagination a:focus {


### PR DESCRIPTION
Currently the information around how many pages with posts are there is not visible anywhere on the page. Giving information like `Page x of y` will help a user understand how many pages of blog posts are there. 

# Before the implementation of this feature
<img width="932" alt="before" src="https://cloud.githubusercontent.com/assets/2050265/17877985/24cf73a6-6905-11e6-9418-b413361250d6.png">

# After the implementation of this feature
<img width="947" alt="after" src="https://cloud.githubusercontent.com/assets/2050265/17877989/30d1d61c-6905-11e6-9e99-9e38167fa672.png">

