### PR TITLE
Escape post title when rendering disqus JS snippet

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -39,7 +39,7 @@ layout: default
   <script type="text/javascript">
     var disqus_shortname  = '{{ site.disqus_shortname }}';
     var disqus_identifier = '{{ page.id }}';
-    var disqus_title      = '{{ page.title }}';
+    var disqus_title      = {{ page.title | jsonify }};
 
     (function() {
       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;


### PR DESCRIPTION
Single quotes in post titles don't break the JS anymore