### PR TITLE
Only show pagination if ...

### DIFF
--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -1,3 +1,4 @@
+{% if paginator.total_pages != 1 %}
 <div class="pagination clearfix mb1 mt4">
   <div class="left">
     {% if paginator.previous_page %}
@@ -19,3 +20,4 @@
   </div>
   <div class="pagination-meta">Page {{ paginator.page }} of {{ paginator.total_pages }}</div>
 </div>
+{% endif %}


### PR DESCRIPTION
Only show pagination if the number of total pages is greater than one. [paginator.total_pages != 1] This only gets relevant if the administrator's site.paginate setting in _config.yml is greater than the number of posts at all [paginator.total_posts]. Keep on rocking!