### PR TITLE
Fix gist display border issue

### DIFF
--- a/_sass/_gists.scss
+++ b/_sass/_gists.scss
@@ -6,3 +6,7 @@
 .gist .lines {
   width: 100%;
 }
+
+.gist table>tbody>tr>td {
+  border-top: 0px;
+}


### PR DESCRIPTION
Embedded gists had a visual border issue:
![gist_fix](https://cloud.githubusercontent.com/assets/5337921/23660772/2fe3b0e8-0353-11e7-9d79-cc5e60f61488.PNG)

And this is the fixed version:
![gist_fix_after](https://cloud.githubusercontent.com/assets/5337921/23660815/4ebccbda-0353-11e7-8d20-5eb07e94bca3.PNG)