### PR TITLE
Replace p tag with span

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,13 +10,13 @@ layout: default
         <div class="post py3">
           <p class="post-meta">{{ post.date | date: site.date_format }}</p>
           <a href="{{ post.url | prepend: site.baseurl }}" class="post-link"><h3 class="h1 post-title">{{ post.title }}</h3></a>
-          <p class="post-summary">
+          <span class="post-summary">
             {% if post.summary %}
               {{ post.summary }}
             {% else %}
               {{ post.excerpt }}
             {% endif %}
-          </p>
+          </span>
         </div>
       {% endfor %}
     </div>


### PR DESCRIPTION
Fix #319 by replacing `<p>` with `<span>` to match the [HTML specification](https://www.w3.org/TR/html401/struct/text.html#h-9.3.1) (which does not allowing nesting block-level elements within `<p>`, including another `<p>`).