### PR TITLE
Provide alternative way to determining whether a page ends up in top navigation

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,10 +1,5 @@
 {% for page in site.pages %}
-    {% if page.tags contains "about" %}
-        <a href="{{ page.url }}">{{ page.title }}</a>
-    {% endif %}
-{% endfor %}
-{% for page in site.pages %}
-    {% if page.tags contains "contact" %}
+    {% if page.top_navigation %}
         <a href="{{ page.url }}">{{ page.title }}</a>
     {% endif %}
 {% endfor %}

--- a/about.md
+++ b/about.md
@@ -2,7 +2,7 @@
 layout: page
 title: About Pixyll
 permalink: /about/
-tags: about
+top_navigation: true
 ---
 
 This Jekyll theme was crafted with <3 by [John Otander](http://johnotander.com)

--- a/contact.html
+++ b/contact.html
@@ -2,7 +2,7 @@
 layout: page
 title: Say Hello
 permalink: /contact/
-tags: contact
+top_navigation: true
 ---
 
 <div class="py2">


### PR DESCRIPTION
To determine whether a page is being shown in top navigation, do not rely on certain tags present in pages. Instead, allow for an explicit setting in page properties.