### PR TITLE
Use site.header_pages for navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,9 @@ description: "A simple, beautiful theme for Jekyll that emphasizes content rathe
 baseurl:     ""
 url:         "http://pixyll.com"
 date_format: "%b %-d, %Y"
+header_pages:
+ - about.md
+ - contact.html
 
 # Google services
 google_verification:

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,10 +1,13 @@
-{% for page in site.pages %}
-    {% if page.tags contains "about" %}
+{% assign default_paths = site.pages | map: "path" %}
+{% assign page_paths = site.header_pages | default: default_paths %}
+
+{% for path in page_paths %}
+    
+    {% assign page = site.pages | where: "path", path | first %}
+    
+    {% if page.title %}
         <a href="{{ page.url }}">{{ page.title }}</a>
     {% endif %}
-{% endfor %}
-{% for page in site.pages %}
-    {% if page.tags contains "contact" %}
-        <a href="{{ page.url }}">{{ page.title }}</a>
-    {% endif %}
+
+    
 {% endfor %}


### PR DESCRIPTION
Per discussion in #340, pixyll should try to be consistent with other jekyll themes and use the `header_pages` variable in the site config for including elements in the site navigation.