### PR TITLE
Fix link button hover border

### DIFF
--- a/_sass/basscss/_base-buttons.scss
+++ b/_sass/basscss/_base-buttons.scss
@@ -25,4 +25,5 @@ button,
 
 .button:hover {
   text-decoration: none;
+  border: 1px solid transparent;
 }


### PR DESCRIPTION
The bug can be seen on the /404.html page. Hovering over a link button, makes the button shrink (the border becomes 0 due to the a:hover styles overriding the .button styles).

This fixes that.