### PR TITLE
Use plugins instead of gems in config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -122,7 +122,7 @@ permalink:    pretty
 paginate:     4
 sass:
   style: compressed
-gems:
+plugins:
   - jekyll-paginate
   - jekyll-sitemap
 # https://github.com/jekyll/jekyll/issues/2938


### PR DESCRIPTION
I was getting warnings with `bundle exec jekyll serve` that `gems` in config is deprecated, and we should be using `plugins` now. This PR fixes that.