### PR TITLE
Fix invalid property

### DIFF
--- a/_sass/_tables.scss
+++ b/_sass/_tables.scss
@@ -6,7 +6,7 @@
 table {
   width: 100%;
   max-width: 100%;
-  margin-bottom: 1.5;
+  margin-bottom: 1.5rem;
   font-size: 1.125rem;
   // Cells
   > thead,


### PR DESCRIPTION
Tables previously had no margin at the bottom, because 1.5 without a unit is
invalid and has no effect.